### PR TITLE
Move device tables into program space

### DIFF
--- a/device/include/EmbMessenger/EmbMessenger.hpp
+++ b/device/include/EmbMessenger/EmbMessenger.hpp
@@ -222,38 +222,6 @@ namespace emb
             }
 
             /**
-             * @brief Registers a command
-             * 
-             * Command must be less than `0xFFF0` (`65520`).
-             * Command must be less than MaxCommands.
-             * Command IDs cannot be reused/overridden.
-             * 
-             * @param id Unique ID for the command
-             * @param command The command to be registered
-             * @return True if successful
-             */
-            /*bool registerCommand(uint8_t id, CommandFunction command)
-            {
-                if (id >= 0xFFF0)
-                {
-                    return false;
-                }
-
-                if (id >= m_command_count)
-                {
-                    return false;
-                }
-
-                if (m_commands[id] != nullptr)
-                {
-                    return false;
-                }
-
-                m_commands[id] = command;
-                return true;
-            }*/
-
-            /**
              * @brief Get the Command ID
              * 
              * For debugging, to be used within your command for sanity checks.
@@ -351,7 +319,7 @@ namespace emb
                                 }
 
                                 #ifdef __AVR__
-                                CommandFunction command = (CommandFunction)pgm_read_ptr(m_commands + m_command_id * sizeof(CommandFunction));
+                                CommandFunction command = (CommandFunction)pgm_read_ptr(m_commands + m_command_id);
                                 #else
                                 CommandFunction command = m_commands[m_command_id];
                                 #endif

--- a/device/include/EmbMessenger/EmbMessenger.hpp
+++ b/device/include/EmbMessenger/EmbMessenger.hpp
@@ -13,6 +13,8 @@
 #include <functional>
 #endif
 
+#define ARRAY_SIZE(arr) sizeof(arr) / sizeof(*arr)
+
 namespace emb
 {
     namespace shared
@@ -27,13 +29,12 @@ namespace emb
          * 
          * EmbMessenger has reserved 16 command IDs for internal usage
          * 
-         * @tparam MaxCommands The maximum number of commands to store, must be less than `65520`
          * @tparam MaxPeriodicCommands The maximum number of periodic commands to store, must be less than `65520`
          */
-        template <uint8_t MaxCommands, uint8_t MaxPeriodicCommands>
+        template <uint8_t MaxPeriodicCommands = 0>
         class EmbMessenger
         {
-        protected:
+        public:
 #ifndef EMB_TESTING
             using CommandFunction = void (*)(void);
             using TimeFunction = uint32_t (*)(void);
@@ -42,6 +43,7 @@ namespace emb
             using TimeFunction = std::function<uint32_t()>;
 #endif
 
+        protected:
             struct PeriodicCommand
             {
                 uint16_t command_id = 65535;
@@ -64,7 +66,8 @@ namespace emb
 
             TimeFunction m_time_func;
 
-            CommandFunction m_commands[MaxCommands];
+            const CommandFunction* m_commands;
+            const uint16_t m_command_count;
             PeriodicCommand m_periodic_commands[MaxPeriodicCommands];
 
             template <typename T, typename... Ts>
@@ -189,18 +192,14 @@ namespace emb
              * 
              * @param buffer Buffer for communication
              */
-            EmbMessenger(shared::IBuffer* buffer) :
+            EmbMessenger(shared::IBuffer* buffer, const CommandFunction commands[], uint16_t commandCount) :
                 m_buffer(buffer),
                 m_reader(buffer),
-                m_writer(buffer)
+                m_writer(buffer),
+                m_commands(commands),
+                m_command_count(commandCount)
             {
-                static_assert(MaxCommands < 0xFFF0, "MaxCommands must be less than 0xFFF0 (65520)");
                 static_assert(MaxPeriodicCommands == 0, "TimeFunction required for periodic commands");
-
-                for (uint8_t i = 0; i < MaxCommands; ++i)
-                {
-                    m_commands[i] = nullptr;
-                }
             }
 
             /**
@@ -209,19 +208,15 @@ namespace emb
              * @param buffer Buffer for communication
              * @param timeFunc A function that keeps track of the time. e.g. `millis()`
              */
-            EmbMessenger(shared::IBuffer* buffer, TimeFunction timeFunc) :
+            EmbMessenger(shared::IBuffer* buffer, const CommandFunction commands[], uint16_t commandCount, TimeFunction timeFunc) :
                 m_buffer(buffer),
                 m_reader(buffer),
                 m_writer(buffer),
+                m_commands(commands),
+                m_command_count(commandCount),
                 m_time_func(timeFunc)
             {
-                static_assert(MaxCommands < 0xFFF0, "MaxCommands must be less than 0xFFF0 (65520)");
                 static_assert(MaxPeriodicCommands < 0xFFF0, "MaxPeriodicCommands must be less than 0xFFF0 (65520)");
-
-                for (uint8_t i = 0; i < MaxCommands; ++i)
-                {
-                    m_commands[i] = nullptr;
-                }
             }
 
             /**
@@ -235,14 +230,14 @@ namespace emb
              * @param command The command to be registered
              * @return True if successful
              */
-            bool registerCommand(uint8_t id, CommandFunction command)
+            /*bool registerCommand(uint8_t id, CommandFunction command)
             {
                 if (id >= 0xFFF0)
                 {
                     return false;
                 }
 
-                if (id >= MaxCommands)
+                if (id >= m_command_count)
                 {
                     return false;
                 }
@@ -254,7 +249,7 @@ namespace emb
 
                 m_commands[id] = command;
                 return true;
-            }
+            }*/
 
             /**
              * @brief Get the Command ID
@@ -345,7 +340,7 @@ namespace emb
                                 unregisterPeriodicCommand();
                                 break;
                             default:
-                                if (m_command_id >= MaxCommands || m_commands[m_command_id] == nullptr)
+                                if (m_command_id >= m_command_count || m_commands[m_command_id] == nullptr)
                                 {
                                     m_writer.writeError(shared::DataError::kCommandIdInvalid);
                                     m_writer.write(m_command_id);

--- a/device/test/EmbMessenger.cpp
+++ b/device/test/EmbMessenger.cpp
@@ -15,67 +15,61 @@ namespace emb
         {
             TEST(device_command, ping)
             {
-                FakeBuffer buffer;
-
-                EmbMessenger<4, 0> messenger(&buffer);
-
                 bool ledState = false;
 
+                std::shared_ptr<EmbMessenger<>> messenger;
+
                 std::function<void()> ping = [&] {};
-                std::function<void()> setLed = [&] { messenger.read(ledState); };
+                std::function<void()> setLed = [&] { messenger->read(ledState); };
                 std::function<void()> toggleLed = [&] {
                     ledState = !ledState;
-                    messenger.write(ledState);
+                    messenger->write(ledState);
                 };
                 std::function<void()> add = [&] {
                     int a, b;
-                    messenger.read(a, b);
-                    messenger.write(a + b);
+                    messenger->read(a, b);
+                    messenger->write(a + b);
                 };
 
-                messenger.registerCommand(0, ping);
-                messenger.registerCommand(1, setLed);
-                messenger.registerCommand(2, toggleLed);
-                messenger.registerCommand(3, add);
+                FakeBuffer buffer;
+                EmbMessenger<>::CommandFunction commands[] = { ping, setLed, toggleLed, add };
+                messenger = std::make_shared<EmbMessenger<>>(&buffer, commands, ARRAY_SIZE(commands));
 
                 buffer.addHostMessage({ 0x01, 0x00 });
-                messenger.update();
+                messenger->update();
                 ASSERT_TRUE(buffer.checkDeviceBuffer({ 0x01 }));
                 ASSERT_TRUE(buffer.buffersEmpty());
             }
 
             TEST(device_command, set_led)
             {
-                FakeBuffer buffer;
-
-                EmbMessenger<4, 0> messenger(&buffer);
-
                 bool ledState = false;
 
+                std::shared_ptr<EmbMessenger<>> messenger;
+
                 std::function<void()> ping = [&] {};
-                std::function<void()> setLed = [&] { messenger.read(ledState); };
+                std::function<void()> setLed = [&] { messenger->read(ledState); };
                 std::function<void()> toggleLed = [&] {
                     ledState = !ledState;
-                    messenger.write(ledState);
+                    messenger->write(ledState);
                 };
                 std::function<void()> add = [&] {
                     int a, b;
-                    messenger.read(a, b);
-                    messenger.write(a + b);
+                    messenger->read(a, b);
+                    messenger->write(a + b);
                 };
 
-                messenger.registerCommand(0, ping);
-                messenger.registerCommand(1, setLed);
-                messenger.registerCommand(2, toggleLed);
-                messenger.registerCommand(3, add);
+                FakeBuffer buffer;
+                EmbMessenger<>::CommandFunction commands[] = { ping, setLed, toggleLed, add };
+                messenger = std::make_shared<EmbMessenger<>>(&buffer, commands, ARRAY_SIZE(commands));
 
                 buffer.addHostMessage({ 0x01, 0x01, shared::DataType::kBoolTrue });
-                messenger.update();
+                messenger->update();
                 ASSERT_TRUE(buffer.checkDeviceBuffer({ 0x01 }));
                 ASSERT_EQ(ledState, true);
 
                 buffer.addHostMessage({ 0x02, 0x01, shared::DataType::kBoolFalse });
-                messenger.update();
+                messenger->update();
                 ASSERT_TRUE(buffer.checkDeviceBuffer({ 0x02 }));
                 ASSERT_EQ(ledState, false);
 
@@ -84,36 +78,33 @@ namespace emb
 
             TEST(device_command, toggle_led)
             {
-                FakeBuffer buffer;
-
-                EmbMessenger<4, 0> messenger(&buffer);
-
                 bool ledState = false;
 
+                std::shared_ptr<EmbMessenger<>> messenger;
+
                 std::function<void()> ping = [&] {};
-                std::function<void()> setLed = [&] { messenger.read(ledState); };
+                std::function<void()> setLed = [&] { messenger->read(ledState); };
                 std::function<void()> toggleLed = [&] {
                     ledState = !ledState;
-                    messenger.write(ledState);
+                    messenger->write(ledState);
                 };
                 std::function<void()> add = [&] {
                     int a, b;
-                    messenger.read(a, b);
-                    messenger.write(a + b);
+                    messenger->read(a, b);
+                    messenger->write(a + b);
                 };
 
-                messenger.registerCommand(0, ping);
-                messenger.registerCommand(1, setLed);
-                messenger.registerCommand(2, toggleLed);
-                messenger.registerCommand(3, add);
+                FakeBuffer buffer;
+                EmbMessenger<>::CommandFunction commands[] = { ping, setLed, toggleLed, add };
+                messenger = std::make_shared<EmbMessenger<>>(&buffer, commands, ARRAY_SIZE(commands));
 
                 buffer.addHostMessage({ 0x01, 0x02 });
-                messenger.update();
+                messenger->update();
                 ASSERT_TRUE(buffer.checkDeviceBuffer({ 0x01, shared::DataType::kBoolTrue }));
                 ASSERT_EQ(ledState, true);
 
                 buffer.addHostMessage({ 0x02, 0x02 });
-                messenger.update();
+                messenger->update();
                 ASSERT_TRUE(buffer.checkDeviceBuffer({ 0x02, shared::DataType::kBoolFalse }));
                 ASSERT_EQ(ledState, false);
 
@@ -122,170 +113,167 @@ namespace emb
 
             TEST(device_command, add)
             {
-                FakeBuffer buffer;
-
-                EmbMessenger<4, 0> messenger(&buffer);
-
                 bool ledState = false;
 
+                std::shared_ptr<EmbMessenger<>> messenger;
+
                 std::function<void()> ping = [&] {};
-                std::function<void()> setLed = [&] { messenger.read(ledState); };
+                std::function<void()> setLed = [&] { messenger->read(ledState); };
                 std::function<void()> toggleLed = [&] {
                     ledState = !ledState;
-                    messenger.write(ledState);
+                    messenger->write(ledState);
                 };
                 std::function<void()> add = [&] {
-                    int a = 0, b = 0;
-                    messenger.read(a, b);
-                    messenger.write(a + b);
+                    int a, b;
+                    messenger->read(a, b);
+                    messenger->write(a + b);
                 };
 
-                messenger.registerCommand(0, ping);
-                messenger.registerCommand(1, setLed);
-                messenger.registerCommand(2, toggleLed);
-                messenger.registerCommand(3, add);
+                FakeBuffer buffer;
+                EmbMessenger<>::CommandFunction commands[] = { ping, setLed, toggleLed, add };
+                messenger = std::make_shared<EmbMessenger<>>(&buffer, commands, ARRAY_SIZE(commands));
 
                 buffer.addHostMessage({ 0x01, 0x03, 0x07, 0x02 });
-                messenger.update();
+                messenger->update();
                 ASSERT_TRUE(buffer.checkDeviceBuffer({ 0x01, 0x09 }));
                 ASSERT_TRUE(buffer.buffersEmpty());
             }
 
             TEST(messenger_builtin_command, register_periodic_commands)
             {
-                FakeBuffer buffer;
+                bool ledState = false;
 
                 uint32_t millis_value = 0;
 
-                EmbMessenger<1, 1> messenger(&buffer, [&]() { return millis_value; });
-
-                bool ledState = false;
+                std::shared_ptr<EmbMessenger<1>> messenger;
 
                 std::function<void()> toggleLed = [&] {
                     ledState = !ledState;
-                    messenger.write(ledState);
+                    messenger->write(ledState);
                 };
 
-                messenger.registerCommand(0, toggleLed);
+                FakeBuffer buffer;
+                EmbMessenger<>::CommandFunction commands[] = { toggleLed };
+                messenger = std::make_shared<EmbMessenger<1>>(&buffer, commands, ARRAY_SIZE(commands),
+                                                              [&]() { return millis_value; });
 
                 buffer.addHostMessage(
                     { 0x01, shared::DataType::kUint16, 0xFF, 0xFE, 0x00, shared::DataType::kUint16, 0x03, 0xE8 });
-                messenger.update();
+                messenger->update();
                 ASSERT_TRUE(buffer.checkDeviceBuffer({ 0x01 }));
                 ASSERT_TRUE(buffer.checkDeviceBuffer({ 0x01, shared::DataType::kBoolTrue }));
                 ASSERT_TRUE(buffer.buffersEmpty());
 
                 millis_value += 600;
-                messenger.update();
+                messenger->update();
                 ASSERT_TRUE(buffer.buffersEmpty());
 
                 millis_value += 600;
-                messenger.update();
+                messenger->update();
                 ASSERT_TRUE(buffer.checkDeviceBuffer({ 0x01, shared::DataType::kBoolFalse }));
                 ASSERT_TRUE(buffer.buffersEmpty());
             }
 
             TEST(messenger_builtin_command, unregister_periodic_commands)
             {
-                FakeBuffer buffer;
+                bool ledState = false;
 
                 uint32_t millis_value = 0;
 
-                EmbMessenger<1, 1> messenger(&buffer, [&]() { return millis_value; });
-
-                bool ledState = false;
+                std::shared_ptr<EmbMessenger<1>> messenger;
 
                 std::function<void()> toggleLed = [&] {
                     ledState = !ledState;
-                    messenger.write(ledState);
+                    messenger->write(ledState);
                 };
 
-                messenger.registerCommand(0, toggleLed);
+                FakeBuffer buffer;
+                EmbMessenger<>::CommandFunction commands[] = { toggleLed };
+                messenger = std::make_shared<EmbMessenger<1>>(&buffer, commands, ARRAY_SIZE(commands),
+                                                              [&]() { return millis_value; });
 
                 buffer.addHostMessage(
                     { 0x01, shared::DataType::kUint16, 0xFF, 0xFE, 0x00, shared::DataType::kUint16, 0x03, 0xE8 });
-                messenger.update();
+                messenger->update();
                 ASSERT_TRUE(buffer.checkDeviceBuffer({ 0x01 }));
                 ASSERT_TRUE(buffer.checkDeviceBuffer({ 0x01, shared::DataType::kBoolTrue }));
                 ASSERT_TRUE(buffer.buffersEmpty());
 
                 millis_value += 600;
                 buffer.addHostMessage({ 0x02, shared::DataType::kUint16, 0xFF, 0xFD, 0x00 });
-                messenger.update();
+                messenger->update();
                 ASSERT_TRUE(buffer.checkDeviceBuffer({ 0x02, 0x01 }));
                 ASSERT_TRUE(buffer.buffersEmpty());
 
                 millis_value += 600;
-                messenger.update();
+                messenger->update();
                 ASSERT_TRUE(buffer.buffersEmpty());
             }
 
             TEST(messenger_builtin_command, reset_periodic_commands)
             {
-                FakeBuffer buffer;
+                bool ledState = false;
 
                 uint32_t millis_value = 0;
 
-                EmbMessenger<1, 1> messenger(&buffer, [&]() { return millis_value; });
-
-                bool ledState = false;
+                std::shared_ptr<EmbMessenger<1>> messenger;
 
                 std::function<void()> toggleLed = [&] {
                     ledState = !ledState;
-                    messenger.write(ledState);
+                    messenger->write(ledState);
                 };
 
-                messenger.registerCommand(0, toggleLed);
+                FakeBuffer buffer;
+                EmbMessenger<>::CommandFunction commands[] = { toggleLed };
+                messenger = std::make_shared<EmbMessenger<1>>(&buffer, commands, ARRAY_SIZE(commands),
+                                                              [&]() { return millis_value; });
 
                 buffer.addHostMessage(
                     { 0x01, shared::DataType::kUint16, 0xFF, 0xFE, 0x00, shared::DataType::kUint16, 0x03, 0xE8 });
-                messenger.update();
+                messenger->update();
                 ASSERT_TRUE(buffer.checkDeviceBuffer({ 0x01 }));
                 ASSERT_TRUE(buffer.checkDeviceBuffer({ 0x01, shared::DataType::kBoolTrue }));
                 ASSERT_TRUE(buffer.buffersEmpty());
 
                 millis_value += 600;
                 buffer.addHostMessage({ 0x02, shared::DataType::kUint16, 0xFF, 0xFF });
-                messenger.update();
+                messenger->update();
                 ASSERT_TRUE(buffer.checkDeviceBuffer({ 0x02 }));
                 ASSERT_TRUE(buffer.buffersEmpty());
 
                 millis_value += 600;
-                messenger.update();
+                messenger->update();
                 ASSERT_TRUE(buffer.buffersEmpty());
             }
 
             TEST(messenger_errors, parameter_read_error)
             {
-                FakeBuffer buffer;
-
-                EmbMessenger<4, 0> messenger(&buffer);
-
                 bool ledState = false;
 
+                std::shared_ptr<EmbMessenger<>> messenger;
+
                 std::function<void()> ping = [&] {};
-                std::function<void()> setLed = [&] { messenger.read(ledState); };
+                std::function<void()> setLed = [&] { messenger->read(ledState); };
                 std::function<void()> toggleLed = [&] {
                     ledState = !ledState;
-                    messenger.write(ledState);
+                    messenger->write(ledState);
                 };
                 std::function<void()> add = [&] {
-                    int a = 0, b = 0;
-                    messenger.read(a, b);
-                    messenger.write(a + b);
+                    int a, b;
+                    messenger->read(a, b);
+                    messenger->write(a + b);
                 };
 
-                messenger.registerCommand(0, ping);
-                messenger.registerCommand(1, setLed);
-                messenger.registerCommand(2, toggleLed);
-                messenger.registerCommand(3, add);
+                FakeBuffer buffer;
+                EmbMessenger<>::CommandFunction commands[] = { ping, setLed, toggleLed, add };
+                messenger = std::make_shared<EmbMessenger<>>(&buffer, commands, ARRAY_SIZE(commands));
 
                 buffer.addHostMessage({ 0x01, 0x03, shared::DataType::kBoolTrue });
                 buffer.addHostMessage({ 0x02, 0x03, 0x07 });
-                messenger.update();
+                messenger->update();
                 ASSERT_TRUE(buffer.checkDeviceBuffer(
                     { 0x01, shared::DataType::kError, shared::DataError::kParameterReadError, 0x00 }));
-                messenger.update();
+                messenger->update();
                 ASSERT_TRUE(buffer.checkDeviceBuffer(
                     { 0x02, shared::DataType::kError, shared::DataError::kParameterReadError, 0x01 }));
 
@@ -294,35 +282,32 @@ namespace emb
 
             TEST(messenger_errors, parameter_invalid)
             {
-                FakeBuffer buffer;
-
-                EmbMessenger<4, 0> messenger(&buffer);
-
                 bool ledState = false;
 
+                std::shared_ptr<EmbMessenger<>> messenger;
+
                 std::function<void()> ping = [&] {};
-                std::function<void()> setLed = [&] { messenger.read(ledState); };
+                std::function<void()> setLed = [&] { messenger->read(ledState); };
                 std::function<void()> toggleLed = [&] {
                     ledState = !ledState;
-                    messenger.write(ledState);
+                    messenger->write(ledState);
                 };
                 std::function<void()> add = [&] {
-                    int a = 0, b = 0;
-                    messenger.read(a, [](int val) { return val != 0; }, b, [](int val) { return val != 0; });
-                    messenger.write(a + b);
+                    int a, b;
+                    messenger->read(a, [](int val) { return val != 0; }, b, [](int val) { return val != 0; });
+                    messenger->write(a + b);
                 };
 
-                messenger.registerCommand(0, ping);
-                messenger.registerCommand(1, setLed);
-                messenger.registerCommand(2, toggleLed);
-                messenger.registerCommand(3, add);
+                FakeBuffer buffer;
+                EmbMessenger<>::CommandFunction commands[] = { ping, setLed, toggleLed, add };
+                messenger = std::make_shared<EmbMessenger<>>(&buffer, commands, ARRAY_SIZE(commands));
 
                 buffer.addHostMessage({ 0x01, 0x03, 0x00, 0x07 });
                 buffer.addHostMessage({ 0x02, 0x03, 0x07, 0x00 });
-                messenger.update();
+                messenger->update();
                 ASSERT_TRUE(buffer.checkDeviceBuffer(
                     { 0x01, shared::DataType::kError, shared::DataError::kParameterInvalid, 0x00 }));
-                messenger.update();
+                messenger->update();
                 ASSERT_TRUE(buffer.checkDeviceBuffer(
                     { 0x02, shared::DataType::kError, shared::DataError::kParameterInvalid, 0x01 }));
 
@@ -331,22 +316,20 @@ namespace emb
 
             TEST(messenger_errors, message_id_read_error)
             {
-                FakeBuffer buffer;
-
-                EmbMessenger<1, 0> messenger(&buffer);
-
-                bool ledState = false;
+                std::shared_ptr<EmbMessenger<>> messenger;
 
                 std::function<void()> ping = [&] {};
 
-                messenger.registerCommand(0, ping);
+                FakeBuffer buffer;
+                EmbMessenger<>::CommandFunction commands[] = { ping };
+                messenger = std::make_shared<EmbMessenger<>>(&buffer, commands, ARRAY_SIZE(commands));
 
                 buffer.addHostMessage({});
                 buffer.addHostMessage({ shared::DataType::kBoolFalse });
-                messenger.update();
+                messenger->update();
                 ASSERT_TRUE(buffer.checkDeviceBuffer(
                     { shared::DataType::kError, shared::DataError::kMessageIdReadError, 0x00 }));
-                messenger.update();
+                messenger->update();
                 ASSERT_TRUE(buffer.checkDeviceBuffer(
                     { shared::DataType::kError, shared::DataError::kMessageIdReadError, 0x00 }));
 
@@ -355,22 +338,20 @@ namespace emb
 
             TEST(messenger_errors, command_id_read_error)
             {
-                FakeBuffer buffer;
-
-                EmbMessenger<1, 0> messenger(&buffer);
-
-                bool ledState = false;
+                std::shared_ptr<EmbMessenger<>> messenger;
 
                 std::function<void()> ping = [&] {};
 
-                messenger.registerCommand(0, ping);
+                FakeBuffer buffer;
+                EmbMessenger<>::CommandFunction commands[] = { ping };
+                messenger = std::make_shared<EmbMessenger<>>(&buffer, commands, ARRAY_SIZE(commands));
 
                 buffer.addHostMessage({ 0x01 });
                 buffer.addHostMessage({ 0x02, shared::DataType::kBoolFalse });
-                messenger.update();
+                messenger->update();
                 ASSERT_TRUE(buffer.checkDeviceBuffer(
                     { 0x01, shared::DataType::kError, shared::DataError::kCommandIdReadError, 0x00 }));
-                messenger.update();
+                messenger->update();
                 ASSERT_TRUE(buffer.checkDeviceBuffer(
                     { 0x02, shared::DataType::kError, shared::DataError::kCommandIdReadError, 0x00 }));
 
@@ -379,22 +360,20 @@ namespace emb
 
             TEST(messenger_errors, command_id_invalid)
             {
-                FakeBuffer buffer;
-
-                EmbMessenger<1, 0> messenger(&buffer);
-
-                bool ledState = false;
+                std::shared_ptr<EmbMessenger<>> messenger;
 
                 std::function<void()> ping = [&] {};
 
-                messenger.registerCommand(0, ping);
+                FakeBuffer buffer;
+                EmbMessenger<>::CommandFunction commands[] = { ping };
+                messenger = std::make_shared<EmbMessenger<>>(&buffer, commands, ARRAY_SIZE(commands));
 
                 buffer.addHostMessage({ 0x01, 0x01 });
                 buffer.addHostMessage({ 0x02, 0x02 });
-                messenger.update();
+                messenger->update();
                 ASSERT_TRUE(buffer.checkDeviceBuffer(
                     { 0x01, shared::DataType::kError, shared::DataError::kCommandIdInvalid, 0x01 }));
-                messenger.update();
+                messenger->update();
                 ASSERT_TRUE(buffer.checkDeviceBuffer(
                     { 0x02, shared::DataType::kError, shared::DataError::kCommandIdInvalid, 0x02 }));
 
@@ -403,19 +382,17 @@ namespace emb
 
             TEST(messenger_errors, crc_invalid)
             {
-                FakeBuffer buffer;
-                buffer.writeValidCrc(false);
-
-                EmbMessenger<2, 0> messenger(&buffer);
-
-                bool ledState = false;
+                std::shared_ptr<EmbMessenger<>> messenger;
 
                 std::function<void()> ping = [&] {};
 
-                messenger.registerCommand(0, ping);
+                FakeBuffer buffer;
+                buffer.writeValidCrc(false);
+                EmbMessenger<>::CommandFunction commands[] = { ping };
+                messenger = std::make_shared<EmbMessenger<>>(&buffer, commands, ARRAY_SIZE(commands));
 
                 buffer.addHostMessage({ 0x01, 0x00 });
-                messenger.update();
+                messenger->update();
                 ASSERT_TRUE(
                     buffer.checkDeviceBuffer({ 0x01, shared::DataType::kError, shared::DataError::kCrcInvalid, 0x00 }));
 
@@ -424,18 +401,16 @@ namespace emb
 
             TEST(messenger_errors, extra_parameters)
             {
-                FakeBuffer buffer;
-
-                EmbMessenger<1, 0> messenger(&buffer);
-
-                bool ledState = false;
+                std::shared_ptr<EmbMessenger<>> messenger;
 
                 std::function<void()> ping = [&] {};
 
-                messenger.registerCommand(0, ping);
+                FakeBuffer buffer;
+                EmbMessenger<>::CommandFunction commands[] = { ping };
+                messenger = std::make_shared<EmbMessenger<>>(&buffer, commands, ARRAY_SIZE(commands));
 
                 buffer.addHostMessage({ 0x01, 0x00, shared::DataType::kBoolFalse });
-                messenger.update();
+                messenger->update();
                 ASSERT_TRUE(buffer.checkDeviceBuffer(
                     { 0x01, shared::DataType::kError, shared::DataError::kExtraParameters, 0x00 }));
 

--- a/device/test/EmbMessenger.cpp
+++ b/device/test/EmbMessenger.cpp
@@ -1,5 +1,6 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <memory>
 
 #include "EmbMessenger/DataType.hpp"
 #include "EmbMessenger/EmbMessenger.hpp"

--- a/host/test/EmbMessenger.cpp
+++ b/host/test/EmbMessenger.cpp
@@ -1,5 +1,6 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <memory>
 
 #include "EmbMessenger/DataType.hpp"
 #include "EmbMessenger/EmbMessenger.hpp"

--- a/shared/include/EmbMessenger/Crc.hpp
+++ b/shared/include/EmbMessenger/Crc.hpp
@@ -4,6 +4,12 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#ifdef __AVR__
+#include <avr/pgmspace.h>
+#else
+#define PROGMEM
+#endif
+
 #if !defined(CRC8) && !defined(CRC16) && !defined(CRC32)
 #define CRC8
 #define CRC16
@@ -65,17 +71,22 @@ namespace emb
                 T Calculate(const T table[], const T crc, const uint8_t data)
                 {
                     uint8_t pos = (uint8_t)((crc ^ ((uint32_t)data << nBits<T>())) >> nBits<T>());
-                    return ((sizeof(T) > 1) ? (crc << 8) : 0) ^ table[pos];
+#ifdef __AVR__
+                    T tableValue = pgm_read_byte_near(table + pos);
+#else
+                    T tableValue = table[pos];
+#endif
+                    return ((sizeof(T) > 1) ? (crc << 8) : 0) ^ tableValue;
                 }
 
 #ifdef CRC8
-                extern const CrcTable<uint8_t> CrcTable8;
+                extern const PROGMEM CrcTable<uint8_t> CrcTable8;
 #endif
 #ifdef CRC16
-                extern const CrcTable<uint16_t> CrcTable16;
+                extern const PROGMEM CrcTable<uint16_t> CrcTable16;
 #endif
 #ifdef CRC32
-                extern const CrcTable<uint32_t> CrcTable32;
+                extern const PROGMEM CrcTable<uint32_t> CrcTable32;
 #endif
             }  // namespace detail
 

--- a/shared/src/Crc.cpp
+++ b/shared/src/Crc.cpp
@@ -9,13 +9,13 @@ namespace emb
             namespace detail
             {
 #ifdef CRC8
-                const CrcTable<uint8_t> CrcTable8 = compute<uint8_t, 0x1D>(0);
+                const PROGMEM CrcTable<uint8_t> CrcTable8 = compute<uint8_t, 0x1D>(0);
 #endif
 #ifdef CRC16
-                const CrcTable<uint16_t> CrcTable16 = compute<uint16_t, 0x1021>(0);
+                const PROGMEM CrcTable<uint16_t> CrcTable16 = compute<uint16_t, 0x1021>(0);
 #endif
 #ifdef CRC32
-                const CrcTable<uint32_t> CrcTable32 = compute<uint32_t, 0x04C11DB7>(0);
+                const PROGMEM CrcTable<uint32_t> CrcTable32 = compute<uint32_t, 0x04C11DB7>(0);
 #endif
             }  // namespace detail
         }  // namespace crc


### PR DESCRIPTION
This pull request moves the CRC table and command array into program space on the device as proposed in issue #8.

These two files were created to show the data memory usage between master and device. They were compiled by avr-gcc for an Arduino Uno.
[master.ino](https://github.com/xxAtrain223/EmbMessenger/files/4014842/master.txt)
```
DATA:    [===       ]  28.6% (used 586 bytes from 2048 bytes)
PROGRAM: [==        ]  17.1% (used 5500 bytes from 32256 bytes)
```

[device_progmem.ino](https://github.com/xxAtrain223/EmbMessenger/files/4014835/device_progmem.txt)
```
DATA:    [==        ]  16.0% (used 328 bytes from 2048 bytes)
PROGRAM: [==        ]  15.3% (used 4926 bytes from 32256 bytes)
```

The CRC table used up 256 bytes and the command array used up 2 bytes per command (on the Arduino Uno). Reading the data from program space only takes 1 more cycle, so not a significant amount of time.